### PR TITLE
Remove deprecated parameter in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,6 +654,8 @@ SPDX-License-Identifier: MIT
 						<arg>--pinentry-mode</arg>
 						<arg>loopback</arg>
 					</gpgArguments>
+					<keyname>${GPG_SIGNING_KEYNAME}</keyname>
+					<passphrase>${GPG_SIGNING_PASSPHRASE}</passphrase>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -654,8 +654,6 @@ SPDX-License-Identifier: MIT
 						<arg>--pinentry-mode</arg>
 						<arg>loopback</arg>
 					</gpgArguments>
-					<keyname>${GPG_SIGNING_KEYNAME}</keyname>
-					<passphrase>${GPG_SIGNING_PASSPHRASE}</passphrase>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: 2023 Martin Helwig -->
<!-- SPDX-License-Identifier: MIT -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
<!-- ! Please do not report security vulnerabilities through public issues, discussions, or pull requests. ! -->
<!-- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->

### Description
Change the build because of following warning:

`[WARNING]  Parameter 'passphrase' (user property 'gpg.passphrase') is deprecated: Do not use this configuration, it may leak sensitive information. Rely on gpg-agent or env variables instead.`
